### PR TITLE
optimize toolbar

### DIFF
--- a/GUI/MenuItem.cpp
+++ b/GUI/MenuItem.cpp
@@ -1,21 +1,21 @@
 #include "MenuItem.h"
 
+int MenuItem::counter = 0;
+
 MenuItem::MenuItem(int fName)
 	:
 	fileName(fName),
 	state(MENU_ITEM_STATE::NORMAL)
 {
-	std::cout << "LOG: MenuItem Inialized succesfully" << std::endl;
+	std::cout << "LOG" << counter++<< ": MenuItem Inialized succesfully" << std::endl;
 }
 
 const std::string MenuItem::BasePath = "images\\MenuItems\\";
 
 std::string MenuItem::getPath()
 {
-	int mode = UI.InterfaceMode;
-	int stat = state;
-	return std::string( BasePath + char(mode) + "\\" +
-						char(stat) + "\\" + std::to_string(fileName) + ".jpg");
+	return std::string( BasePath + char(UI.InterfaceMode) + "\\" +
+						char(state) + "\\" + std::to_string(fileName) + ".jpg");
 }
 
 void MenuItem::setState(MENU_ITEM_STATE state_val)
@@ -25,5 +25,5 @@ void MenuItem::setState(MENU_ITEM_STATE state_val)
 
 MenuItem::~MenuItem()
 {
-	std::cout << "LOG: MenuItem destructor called" << std::endl;
+	std::cout << "LOG"<<--counter<<": MenuItem destructor called" << std::endl;
 }

--- a/GUI/MenuItem.h
+++ b/GUI/MenuItem.h
@@ -6,14 +6,17 @@
 class MenuItem
 {
 private:
+	static int counter;
 	static const std::string BasePath;
 	const int fileName; //is a number to represent the file index in the toolbar
 	MENU_ITEM_STATE state; //highlighted or normal
 public:
 	MenuItem() = delete;
 	MenuItem(int fName = -1);
-	std::string getPath();
 	void setState(MENU_ITEM_STATE state_val);
+
+	//this function will return the path to photo according to the state and index of it in the array in ToolBar
+	std::string getPath();
 	~MenuItem();
 };
 #endif

--- a/GUI/Output.cpp
+++ b/GUI/Output.cpp
@@ -4,11 +4,17 @@
 Output::Output()
 {
 	//Initialize the toolbars of the two modes
-	PToolBar = new ToolBar(PLAY_ITM_COUNT);
-	DToolBar = new ToolBar(DRAW_ITM_COUNT);
+	UI.MaxNItems			= (DRAW_ITM_COUNT > PLAY_ITM_COUNT) ? DRAW_ITM_COUNT : PLAY_ITM_COUNT;
+
+	//this is just one tool bar that will draw itself according to the program mode 
+	//it contains the max number of items that can be in draw or play mode so no need for doublicating
+	//items, each MenuItem in the tool bar can draw itself according to the index and state and mode,
+	//for more information see MenuItem.h
+	toolBar = new ToolBar(UI.MaxNItems);
+
+	//DToolBar = new ToolBar(DRAW_ITM_COUNT);
 	//Initialize user interface parameters
 	UI.InterfaceMode		= MODE_DRAW;
-	UI.MaxNItems			= (DRAW_ITM_COUNT > PLAY_ITM_COUNT) ? DRAW_ITM_COUNT : PLAY_ITM_COUNT;
 	UI.FreeSpaceInToolBar	= 5;
 	UI.MenuItemWidth		= 48;
 	UI.MenuItemHeight		= 48;
@@ -79,7 +85,7 @@ void Output::drawToolBar() const
 	int nItems = UI.InterfaceMode == MODE_PLAY ? PLAY_ITM_COUNT : DRAW_ITM_COUNT;
 	for (int i = 0; i < nItems; i++)
 	{
-		std::string itemPath = DToolBar->getItem(i)->getPath();
+		std::string itemPath = toolBar->getItem(i)->getPath();
 		pWind->DrawImage(itemPath, i * UI.MenuItemWidth, 0, UI.MenuItemWidth, UI.MenuItemHeight);
 	}
 }
@@ -160,7 +166,6 @@ void Output::DrawRect(Point P1, Point P2, GfxInfo RectGfxInfo, bool selected) co
 Output::~Output()
 {
 	delete pWind;
-	delete PToolBar;
-	delete DToolBar;
+	delete toolBar;
 }
 

--- a/GUI/Output.h
+++ b/GUI/Output.h
@@ -7,8 +7,7 @@ class Output	//The application manager should have a pointer to this class
 {
 private:	
 	window* pWind;		//Pointer to the Graphics Window
-	ToolBar* PToolBar;	//Pointer to the play toolbar
-	ToolBar* DToolBar;	//Pointer to the draw toolbar
+	ToolBar* toolBar;	//Pointer to the play toolbar
 public:
 	Output();		
 


### PR DESCRIPTION
make just one toolbar instead of two to optimize the space that each item will take, instead of number of items = number of draw items + number of play items , it now just number of max of both.